### PR TITLE
Simplify the spec to only include the ! nullability designator

### DIFF
--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -48,7 +48,7 @@ Token ::
 - FloatValue
 - StringValue
 
-Punctuator :: one of ! ? $ & ( ) ... : = @ [ ] { | }
+Punctuator :: one of ! $ & ( ) ... : = @ [ ] { | }
 
 Name ::
 
@@ -170,7 +170,6 @@ ListNullability : `[` Nullability? `]`
 NullabilityDesignator :
 
 - `!`
-- `?`
 
 Arguments[Const] : ( Argument[?Const]+ )
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -530,8 +530,9 @@ NullabilityDesignator :
 
 Fields can have their nullability designated with a `!` to indicate that a field
 should be `Non-Nullable`. These designators override the nullability set on a
-field by the schema for the operation where they're being used. If a field marked with `!` resolves to `null`, it behaves
-as if the field had been `Non-Nullable` in the schema.
+field by the schema for the operation where they're being used. If a field
+marked with `!` resolves to `null`, it behaves as if the field had been
+`Non-Nullable` in the schema.
 
 In this example, we can indicate that a `user`'s `name` that could possibly be
 `null`, should not be `null`:
@@ -601,8 +602,21 @@ Any field without a nullability designator will inherit its nullability from the
 schema definition. When designating nullability for list fields, query authors
 can either use the designator `!` to designate the nullability of the entire
 field, or they can use the list element nullability syntax displayed above. The
-number of dimensions indicated by list element nullability syntax cannot exceed the number of dimensions of the field. Anything else results in a query
-validation error.
+number of dimensions indicated by list element nullability syntax cannot exceed
+the number of dimensions of the field. Anything else results in a query
+validation error. Both are valid examples:
+
+```graphql example
+{
+  threeDimensionalMatrix[[[!]]]
+}
+```
+
+```graphql example
+{
+  threeDimensionalMatrix[[[!]!]!]!
+}
+```
 
 ## Fragments
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -177,7 +177,7 @@ characters are permitted between the characters defining a {FloatValue}.
 
 ### Punctuators
 
-Punctuator :: one of ! ? $ & ( ) ... : = @ [ ] { | }
+Punctuator :: one of ! $ & ( ) ... : = @ [ ] { | }
 
 GraphQL documents include punctuation in order to describe structure. GraphQL is
 a data description language and not a programming language, therefore GraphQL
@@ -527,25 +527,19 @@ ListNullability : `[` Nullability? `]`
 NullabilityDesignator :
 
 - `!`
-- `?`
 
-Fields can have their nullability designated with either a `!` to indicate that
-a field should be `Non-Nullable` or a `?` to indicate that a field should be
-`Nullable`. These designators override the nullability set on a field by the
-schema for the operation where they're being used. In addition to being
-`Non-Nullable`, if a field marked with `!` resolves to `null`, it propagates to
-the nearest parent field marked with a `?` or to `data` if there is not a parent
-marked with a `?`. An error is added to the `errors` array identical to if the
-field had been `Non-Nullable` in the schema.
+Fields can have their nullability designated with a `!` to indicate that a field
+should be `Non-Nullable`. These designators override the nullability set on a
+field by the schema for the operation where they're being used. In addition to
+being `Non-Nullable`, if a field marked with `!` resolves to `null`, it behaves
+as if the field had been `Non-Nullable` in the schema.
 
 In this example, we can indicate that a `user`'s `name` that could possibly be
-`null`, should not be `null` and that `null` propagation should halt at the
-`user` field. We can use `?` to create null propagation boundary. `user` will be
-treated as `Nullable` for this operation:
+`null`, should not be `null`:
 
 ```graphql example
 {
-  user(id: 4)? {
+  user(id: 4) {
     id
     name!
   }
@@ -583,61 +577,34 @@ marked `Non-Nullable` in the schema:
 }
 ```
 
-If `!` is used on a field and it is not paired with `?` on a parent, then `null`
-will propagate all the way to the `data` response field.
+Nullability designators can also be applied to list elements like so.
 
 ```graphql example
 {
   user(id: 4) {
     id
-    name!
-  }
-}
-```
-
-Response:
-
-```json example
-{
-  "data": null,
-  "errors": [
-    {
-      "locations": [{ "column": 13, "line": 4 }],
-      "message": "Cannot return null for non-nullable field User.name.",
-      "path": ["user", "name"]
-    }
-  ]
-}
-```
-
-Nullability designators can also be applied to list elements like so.
-
-```graphql example
-{
-  user(id: 4)? {
-    id
-    petsNames[!]?
+    petsNames[!]
   }
 }
 ```
 
 In the above example, the query author is saying that each individual pet name
-should be `Non-Nullable`, but the list as a whole should be `Nullable`. The same
-syntax can be applied to multidimensional lists.
+should be `Non-Nullable`. The same syntax can be applied to multidimensional
+lists.
 
 ```graphql example
 {
-  threeDimensionalMatrix[[[?]!]]!
+  threeDimensionalMatrix[[[]!]]!
 }
 ```
 
 Any field without a nullability designator will inherit its nullability from the
 schema definition. When designating nullability for list fields, query authors
-can either use a single designator (`!` or `?`) to designate the nullability of
-the entire field, or they can use the list element nullability syntax displayed
-above. The number of dimensions indicated by list element nullability syntax is
-required to match the number of dimensions of the field. Anything else results
-in a query validation error.
+can either use the designator `!` to designate the nullability of the entire
+field, or they can use the list element nullability syntax displayed above. The
+number of dimensions indicated by list element nullability syntax is required to
+match the number of dimensions of the field. Anything else results in a query
+validation error.
 
 ## Fragments
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -530,8 +530,7 @@ NullabilityDesignator :
 
 Fields can have their nullability designated with a `!` to indicate that a field
 should be `Non-Nullable`. These designators override the nullability set on a
-field by the schema for the operation where they're being used. In addition to
-being `Non-Nullable`, if a field marked with `!` resolves to `null`, it behaves
+field by the schema for the operation where they're being used. If a field marked with `!` resolves to `null`, it behaves
 as if the field had been `Non-Nullable` in the schema.
 
 In this example, we can indicate that a `user`'s `name` that could possibly be
@@ -602,8 +601,7 @@ Any field without a nullability designator will inherit its nullability from the
 schema definition. When designating nullability for list fields, query authors
 can either use the designator `!` to designate the nullability of the entire
 field, or they can use the list element nullability syntax displayed above. The
-number of dimensions indicated by list element nullability syntax is required to
-match the number of dimensions of the field. Anything else results in a query
+number of dimensions indicated by list element nullability syntax cannot exceed the number of dimensions of the field. Anything else results in a query
 validation error.
 
 ## Fragments

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -592,18 +592,18 @@ fragment conflictingDifferingResponses on Pet {
   - If {designatorDepth} is 0
     - return true
   - Let {typeDepth} be the number of list dimensions in {fieldType}
-  - If {typeDepth} equals {designatorDepth} or {designatorDepth} equals 0 return
-    true
-  - Otherwise return false
+  - If {designatorDepth} exceeds {typeDepth} return false
+  - Otherwise return true
 
 **Explanatory Text**
 
-List fields can be marked with nullability designators that look like `[?]!` to
+List fields can be marked with nullability designators that look like `[!]!` to
 indicate the nullability of the list's elements and the nullability of the list
 itself. For multi-dimensional lists, the designator would look something like
-`[[[!]?]]!`. If any `ListNullability` operators are used then the number of
-dimensions of the designator are required to match the number of dimensions of
-the field's type. If the two do not match then a validation error is thrown.
+`[[[!]]]!`. If any `ListNullability` operators are used then the number of
+dimensions of the designator are required be less than the number of dimensions
+of the field's type. If the number of dimensions of the designator exceed the
+number of dimensions of the field's type, then a validation error is thrown.
 
 ### Leaf Field Selections
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -601,9 +601,10 @@ List fields can be marked with nullability designators that look like `[!]!` to
 indicate the nullability of the list's elements and the nullability of the list
 itself. For multi-dimensional lists, the designator would look something like
 `[[[!]]]!`. If any `ListNullability` operators are used then the number of
-dimensions of the designator are required to be less than or equal to the number of dimensions
-of the field's type. If the number of dimensions of the designator exceed the
-number of dimensions of the field's type, then a validation error is thrown.
+dimensions of the designator are required to be less than or equal to the number
+of dimensions of the field's type. If the number of dimensions of the designator
+exceed the number of dimensions of the field's type, then a validation error is
+thrown.
 
 ### Leaf Field Selections
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -601,7 +601,7 @@ List fields can be marked with nullability designators that look like `[!]!` to
 indicate the nullability of the list's elements and the nullability of the list
 itself. For multi-dimensional lists, the designator would look something like
 `[[[!]]]!`. If any `ListNullability` operators are used then the number of
-dimensions of the designator are required be less than the number of dimensions
+dimensions of the designator are required to be less than or equal to the number of dimensions
 of the field's type. If the number of dimensions of the designator exceed the
 number of dimensions of the field's type, then a validation error is thrown.
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -593,10 +593,10 @@ currentPropagationPath, ccnPropagationPairs):
 ## Accounting For Client Controlled Nullability Designators
 
 A field can have its nullability status set either in its service's schema, or a
-nullability designator (`!` or `?`) can override it for the duration of an
-execution. In order to determine a field's true nullability, both are taken into
-account and a final type is produced. A field marked with a `!` is called a
-"required field" and a field marked with a `?` is called an optional field.
+nullability designator (`!`) can override it for the duration of an execution.
+In order to determine a field's true nullability, both are taken into account
+and a final type is produced. A field marked with a `!` is called a "required
+field".
 
 ApplyRequiredStatus(type, requiredStatus):
 
@@ -865,9 +865,6 @@ Since `Non-Null` type fields cannot be {null}, field errors are propagated to be
 handled by the parent field. If the parent field may be {null} then it resolves
 to {null}, otherwise if it is a `Non-Null` type, the field error is further
 propagated to its parent field.
-
-If a required field resolves to {null}, propagation instead happens until an
-optional field is found.
 
 If a `List` type wraps a `Non-Null` type, and one of the elements of that list
 resolves to {null}, then the entire list must resolve to {null}. If the `List`

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -161,11 +161,9 @@ The response might look like:
 ```
 
 If the field which experienced an error was declared as `Non-Null`, the `null`
-result will propagate to the next nullable field. If it was marked with a
-required designator, then it will propagate to the nearest optional parent field
-instead. In either case, the `path` for the error should include the full path
-to the result field where the error was raised, even if that field is not
-present in the response.
+result will propagate to the next nullable field. In that case, the `path` for
+the error should include the full path to the result field where the error was
+raised, even if that field is not present in the response.
 
 For example, if the `name` field from above had declared a `Non-Null` return
 type in the schema, the result would look different but the error reported would


### PR DESCRIPTION
I've made two changes in this PR:

1. Remove the `?` nullability designator
2. Relax the validation rule to prevent the designator depth from exceeding the type depth. I realize that it's too restrictive to require a matching designator path with only `!`.